### PR TITLE
empty the session in the start of a clustering request

### DIFF
--- a/ida-ws/src/main/java/upb/ida/provider/ParamsHandler.java
+++ b/ida-ws/src/main/java/upb/ida/provider/ParamsHandler.java
@@ -44,7 +44,12 @@ public class ParamsHandler implements Subroutine {
 	public String call (com.rivescript.RiveScript rs, String[] args) {
 
 		try {
-		
+			
+			// Emptying the session
+			sessionUtil.getSessionMap().remove("clusterParams");
+			sessionUtil.getSessionMap().remove("colledtedParams");
+			sessionUtil.getSessionMap().remove("algoName");
+			
 			List<ClusterParam> paramList=  new ArrayList<>();
 			 /**
              * getting List of type ClusterParam for parameters of an algorithm


### PR DESCRIPTION
Session should be empty in the start of a new request for clustering.
I have tested the application with this change and everything works fine.