### PR TITLE
Old messages iteration for IDA chatbox

### DIFF
--- a/ida-chatbot/src/app/components/message-form/message-form.component.html
+++ b/ida-chatbot/src/app/components/message-form/message-form.component.html
@@ -2,11 +2,11 @@
 <div style="height: 10px;margin-top: 10px;">
 <mat-progress-bar mode="indeterminate" *ngIf="showBar"></mat-progress-bar>
 </div>
-<form (keyup.enter)="keyDownFunction($event,chatmsg.value) || chatmsg.value = null" style="margin-top: 10px" fxLayout="column" fxLayoutGap="0">
+<form (keydown.enter)="keyDownFunction()" style="margin-top: 10px" fxLayout="column" fxLayoutGap="0">
   <mat-form-field fxFlex>
     <textarea #chatmsg matInput placeholder="Message"></textarea>
   </mat-form-field>
   <div fxFlex>
-    <button #sendbtn mat-raised-button (click)="sendMessage(chatmsg.value) || chatmsg.value = null" >Send</button>
+    <button #sendbtn mat-raised-button (click)="sendMessage()" >Send</button>
   </div>
 </form>

--- a/ida-chatbot/src/app/components/message-form/message-form.component.html
+++ b/ida-chatbot/src/app/components/message-form/message-form.component.html
@@ -2,7 +2,7 @@
 <div style="height: 10px;margin-top: 10px;">
 <mat-progress-bar mode="indeterminate" *ngIf="showBar"></mat-progress-bar>
 </div>
-<form (keydown.enter)="keyDownFunction()" style="margin-top: 10px" fxLayout="column" fxLayoutGap="0">
+<form (keydown.enter)="sendMessage()" (keydown.arrowup)="iterateMsgs('up')" (keydown.arrowdown)="iterateMsgs('down')" style="margin-top: 10px" fxLayout="column" fxLayoutGap="0">
   <mat-form-field fxFlex>
     <textarea #chatmsg matInput placeholder="Message"></textarea>
   </mat-form-field>

--- a/ida-chatbot/src/app/components/message-form/message-form.component.ts
+++ b/ida-chatbot/src/app/components/message-form/message-form.component.ts
@@ -11,6 +11,8 @@ export class MessageFormComponent implements OnInit {
   @Output() msgemitter = new EventEmitter<Message>();
   constructor(private restservice: RestService) { }
   public showBar = false;
+  @ViewChild('chatmsg') chatmsg: ElementRef;
+
   ngOnInit() {
     this.restservice.requestEvnt.subscribe(val => { this.toggleProgressBar(val); });
   }
@@ -18,18 +20,17 @@ export class MessageFormComponent implements OnInit {
     this.showBar = showBar;
   }
 
-  sendMessage(msg: string) {
-    if (msg == null || !msg) {
-      return false;
+  sendMessage() {
+    const msg = this.chatmsg.nativeElement.value.trim();
+    if (msg) {
+      const curTime = new Date();
+      const message = new Message(msg, 'User', 'user', curTime);
+      this.chatmsg.nativeElement.value = '';
+      this.msgemitter.emit(message);
     }
-    const curTime = new Date();
-    const message = new Message(msg, 'User', 'user', curTime);
-    this.msgemitter.emit(message);
   }
 
-  keyDownFunction(event,msg: string) {
-    if (event.keyCode === 13) {
-      this.sendMessage(msg);
-    }
+  keyDownFunction() {
+    this.sendMessage();
   }
 }

--- a/ida-chatbot/src/app/components/message-form/message-form.component.ts
+++ b/ida-chatbot/src/app/components/message-form/message-form.component.ts
@@ -9,9 +9,12 @@ import {RestService} from '../../service/rest/rest.service';
 })
 export class MessageFormComponent implements OnInit {
   @Output() msgemitter = new EventEmitter<Message>();
-  constructor(private restservice: RestService) { }
-  public showBar = false;
   @ViewChild('chatmsg') chatmsg: ElementRef;
+
+  public showBar = false;
+  msgs_history = [];
+  msgs_tracker = 0;
+  constructor(private restservice: RestService) { }
 
   ngOnInit() {
     this.restservice.requestEvnt.subscribe(val => { this.toggleProgressBar(val); });
@@ -26,11 +29,19 @@ export class MessageFormComponent implements OnInit {
       const curTime = new Date();
       const message = new Message(msg, 'User', 'user', curTime);
       this.chatmsg.nativeElement.value = '';
+      this.msgs_history.push(msg);
       this.msgemitter.emit(message);
+      this.msgs_tracker = this.msgs_history.length;
     }
   }
 
-  keyDownFunction() {
-    this.sendMessage();
+  iterateMsgs(direction) {
+    if (this.msgs_history.length) {
+      if (direction === 'up' && this.msgs_tracker > 0) {
+        this.chatmsg.nativeElement.value = this.msgs_history[--this.msgs_tracker];
+      } else if (direction === 'down' && this.msgs_tracker < this.msgs_history.length - 1) {
+        this.chatmsg.nativeElement.value = this.msgs_history[++this.msgs_tracker];
+      }
+    }
   }
 }

--- a/ida-chatbot/src/app/components/message-form/message-form.component.ts
+++ b/ida-chatbot/src/app/components/message-form/message-form.component.ts
@@ -12,8 +12,8 @@ export class MessageFormComponent implements OnInit {
   @ViewChild('chatmsg') chatmsg: ElementRef;
 
   public showBar = false;
-  msgs_history = [];
-  msgs_tracker = 0;
+  msgs_history = []; // This will maintain history of all messages
+  msgs_tracker = 0; // This will keep position of current message from history
   constructor(private restservice: RestService) { }
 
   ngOnInit() {
@@ -35,7 +35,16 @@ export class MessageFormComponent implements OnInit {
     }
   }
 
+  /**
+   * This will let user to iterate over messages from history like
+   * Terminal
+   * Remember, its just in Browser memory so it will go away with
+   * Page refresh. We can later think about it to store in DB
+   *
+   * @param direction
+   */
   iterateMsgs(direction) {
+    // Checking if we have any message in history or not
     if (this.msgs_history.length) {
       if (direction === 'up' && this.msgs_tracker > 0) {
         this.chatmsg.nativeElement.value = this.msgs_history[--this.msgs_tracker];


### PR DESCRIPTION
This functionality will enable IDA's user to cycle through previous messages just like Terminal.
**Note**
Remember, its just in Browser memory so it will go away with Page refresh. We can later think about it to store in DB