### PR TITLE
fix(ida-124): fixed drag and zoom problem with bubble chart

### DIFF
--- a/frontend/src/components/visualizations/bubblechart/bubblechart.js
+++ b/frontend/src/components/visualizations/bubblechart/bubblechart.js
@@ -37,9 +37,12 @@ export default class IDABubbleGraph extends Component {
       const svg = d3.select("#" + this.containerId)
         .append("svg")
         .attr("height", this.height)
-        .attr("width", this.width);
+        .attr("width", "100%");
 
-      const entry = svg.selectAll("g")
+      // Top level group to facilitate zoom and drag functionality
+	  const top_group = svg.append("g");
+
+      const entry = top_group.selectAll("g")
         .data(root.leaves())
         .join("g")
         .attr("transform", d => `translate(${d.x + 1},${d.y + 1})`);
@@ -61,8 +64,11 @@ export default class IDABubbleGraph extends Component {
         .text(d => (d.data.description + ':  ' + d.value));
 
       const zoom = d3.zoom()
-        .scaleExtent([0.1, 10])
-        .on('zoom', function (event) { svg.attr('transform', event.transform); });
+        .scaleExtent([0.5, 5])
+        .on('zoom', (event) => {
+        	// we want to drag all the bubbles so we put transform on top_group
+			top_group.attr('transform', event.transform);
+        });
       svg.call(zoom);
     }
   }

--- a/frontend/src/components/visualizations/bubblechart/bubblechart.js
+++ b/frontend/src/components/visualizations/bubblechart/bubblechart.js
@@ -64,7 +64,7 @@ export default class IDABubbleGraph extends Component {
         .text(d => (d.data.description + ':  ' + d.value));
 
       const zoom = d3.zoom()
-        .scaleExtent([0.5, 5])
+        .scaleExtent([0.1, Infinity])
         .on('zoom', (event) => {
         	// we want to drag all the bubbles so we put transform on top_group
 			top_group.attr('transform', event.transform);


### PR DESCRIPTION
The problem was we were applying `zoom` on whole `<svg>` element and it was causing the problem.
And the solution is to have a top-level `<g>` which houses all other `<circle>` groups and then apply `zoom` on this top-level `<g>`