### PR TITLE
Cluster table and hosting port change

### DIFF
--- a/frontend/src/components/datatable/datatable.js
+++ b/frontend/src/components/datatable/datatable.js
@@ -103,16 +103,18 @@ export default class CustomizedTables extends Component {
   }
 
   componentDidMount() {
-    if (this.tableId && document.getElementById(this.tableId)) {
-      const rowHeight = document.getElementById(this.tableId).getElementsByClassName("ida-table-row")[0].offsetHeight;
-      if (rowHeight) {
-        const defaultRowsPerPage = Math.floor((window.innerHeight * 0.65) / rowHeight);
-        this.setState({
-          rowsPerPage: defaultRowsPerPage,
-          rowsPerPageList: [defaultRowsPerPage, defaultRowsPerPage * 2, defaultRowsPerPage * 3, defaultRowsPerPage * 4, defaultRowsPerPage * 5]
-        });
+    setTimeout(() => {
+      if (this.tableId && document.getElementById(this.tableId)) {
+        const rowHeight = document.getElementById(this.tableId).getElementsByClassName("ida-table-row")[0].offsetHeight;
+        if (rowHeight) {
+          const defaultRowsPerPage = Math.floor((window.innerHeight * 0.65) / rowHeight);
+          this.setState({
+            rowsPerPage: defaultRowsPerPage,
+            rowsPerPageList: [defaultRowsPerPage, defaultRowsPerPage * 2, defaultRowsPerPage * 3, defaultRowsPerPage * 4, defaultRowsPerPage * 5]
+          });
+        }
       }
-    }
+    }, 100);
   }
 
   handleChangePage(event, newPage) {

--- a/services/backend-server/Dockerfile.dev
+++ b/services/backend-server/Dockerfile.dev
@@ -4,6 +4,6 @@ COPY backend-server/pom.xml backend-server/pom.xml
 COPY backend-server/src backend-server/src
 
 WORKDIR /build/backend-server
+RUN mvn dependency:go-offline
 EXPOSE 8080
-RUN mvn package
 CMD mvn spring-boot:run

--- a/services/backend-server/Dockerfile.prod
+++ b/services/backend-server/Dockerfile.prod
@@ -4,6 +4,7 @@ COPY backend-server/pom.xml backend-server/pom.xml
 COPY backend-server/src backend-server/src
 
 WORKDIR /build/backend-server
+RUN mvn dependency:go-offline
 RUN export GOOGLE_APPLICATION_CREDENTIALS="/build/backend-server/src/main/resources/ida-chatbot-dialogflow.json"
 RUN mvn package
 

--- a/services/docker-compose-prod.yml
+++ b/services/docker-compose-prod.yml
@@ -5,6 +5,7 @@ services:
     image: $REGISTRY/ida/nginx:$VERSION
     ports:
       - 8080:80
+      - 80:80
     networks:
       - ida-net
   ida-backend:


### PR DESCRIPTION
* Clustered data table takes all the available height on the screen
* IDA production instance is hosted on both ports 8080 and 80 now
* Adding sample solution to speed up docker deployments